### PR TITLE
Make the login page more "secure", properly redirect `/user/x` pages

### DIFF
--- a/functions/login.ts
+++ b/functions/login.ts
@@ -5,11 +5,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   let username = formData.get('username')
   const password = formData.get('password')
 
-  if (username !== '' && password !== '') {
-    if (username === 'admin') {
-      username = 'admin7'
-    }
-
+  const auth = {
+    'cooper': 'cooper',
+    'stanford': 'stanford',
+  }
+  if (auth[username] === password) {
     return new Response(null, {
       status: 303,
       headers: {
@@ -20,7 +20,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   }
 
   return new Response(
-    `Invalid username or password`,
+    `Invalid username or password, you will be redirected in 3 seconds
+    <meta http-equiv="refresh" content="3;url=/login"/>`,
     {
       status: 400,
       headers: {

--- a/functions/user/[id].ts
+++ b/functions/user/[id].ts
@@ -1,5 +1,10 @@
 interface Env { }
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
-  return Response.redirect(`/user?id=${context.params.id}`)
+  return new Response(null, {
+    status: 303,
+    headers: {
+      'Location': `/user?id=${context.params.id}`,
+    },
+  })
 }


### PR DESCRIPTION
The login page now requires correct username/password combos instead of anything:
- cooper:cooper as mentioned in the comments
- stanford:stanford as mentioned at the class
- Admin does not have an actual password, as learning about bruteforce/dictionary attacks doesn't seem to be the goal of this endpoint
This has the added goal of removing the unintended XSS (such as by login in with an XSS payload as a username).

Invalid username/password combos will be redirected back to the login page after 3 seconds.

The `/user/0` endpoint now works correctly.